### PR TITLE
Implement threaded predict pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # infer_server
+
+This gRPC service batches incoming images and performs pose detection with
+multiple worker threads.
+
+## Configuration
+
+- `num_workers` in `config.py` controls the number of threads used for
+  inference. Each thread creates its own `BatchWorker` on first use.
+
+## Architecture
+
+```
+PoseDetectionService
+    └─ BatchProcessor (collects requests)
+        └─ PredictThreadPool → BatchWorker
+```

--- a/core/predict_pool.py
+++ b/core/predict_pool.py
@@ -1,0 +1,44 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+
+from model.batch_worker import BatchWorker
+from metrics.event_bus import event_bus
+from config import settings
+
+_thread_local = threading.local()
+
+class PredictThreadPool:
+    """Thread pool that lazily creates a BatchWorker per thread."""
+
+    def __init__(self, num_workers: int | None = None):
+        self.num_workers = num_workers or settings.num_workers
+        self.executor = ThreadPoolExecutor(max_workers=self.num_workers)
+
+    def _get_worker(self) -> BatchWorker:
+        if not hasattr(_thread_local, "worker"):
+            _thread_local.worker = BatchWorker()
+        return _thread_local.worker
+
+    def _predict(self, batch_images, wrappers, trigger_time):
+        worker = self._get_worker()
+        start = time.time()
+        with wrappers[0].logger.phase("inference"):
+            results = worker.predict(batch_images)
+        end = time.time()
+        print(
+            f"[Batch] Inference: {(end - start)*1000:.2f} ms, "
+            f"Total Cycle: {(time.time() - (start - trigger_time))*1000:.2f} ms"
+        )
+        return results
+
+    def _on_complete(self, future, wrappers):
+        results = future.result()
+        for wrapper, result in zip(wrappers, results):
+            wrapper.result_queue.put(result)
+        event_bus.emit("batch_processed", batch_size=len(wrappers))
+
+    def submit(self, batch_images, wrappers, trigger_time):
+        future = self.executor.submit(self._predict, batch_images, wrappers, trigger_time)
+        future.add_done_callback(lambda fut, w=wrappers: self._on_complete(fut, w))
+        return future

--- a/main.py
+++ b/main.py
@@ -22,8 +22,12 @@ def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=100))
     health_pb2_grpc.add_HealthServicer_to_server(HealthServicer(), server)
     pose_pb2_grpc.add_MirrorServicer_to_server(
-        PoseDetectionService(batch_size=settings.batch_size, timeout=settings.queue_timeout),
-        server
+        PoseDetectionService(
+            batch_size=settings.batch_size,
+            timeout=settings.queue_timeout,
+            num_workers=settings.num_workers,
+        ),
+        server,
     )
     server.add_insecure_port('[::]:' + settings.gRPC_port)
     server.start()


### PR DESCRIPTION
## Summary
- introduce `PredictThreadPool` to manage `BatchWorker`s
- connect `BatchProcessor` and `PoseDetectionService` to the pool
- pass `num_workers` from `settings` in `main.py`
- document worker setting and architecture

## Testing
- `python -m py_compile core/predict_pool.py processor/batch_processor.py service/pose_service.py main.py model/batch_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f38eb1508331b595885f03009ac2