### PR TITLE
Run admin API in same process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # infer_server
 ## Admin API
 
-Run `python admin_api.py` to start a FastAPI server on port 8000 providing batching configuration endpoints:
+The admin API is started automatically when running `python main.py`. It exposes batching configuration endpoints on port 8000:
 - `GET /config/batching` returns current batch settings
 - `POST /config/batching` with JSON `{ "batch_size": int, "queue_timeout": float }` updates the runtime behavior.
+Standalone mode is still available by running `python admin_api.py`.
 


### PR DESCRIPTION
## Summary
- run FastAPI admin endpoints inside the gRPC server process
- update README to mention that the admin API starts automatically

## Testing
- `git ls-files '*.py' | while read -r f; do python -m py_compile "$f" || break; done`

------
https://chatgpt.com/codex/tasks/task_e_684742fbcab8833195d5723ddc461f80