### PR TITLE
Add Cython-based postprocessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore Python cache and build artifacts
+__pycache__/
+*.pyc
+
+# Cython build directories
+build/
+*.c
+*.so

--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ The admin API is started automatically when running `python main.py`. It exposes
 - `POST /config/batching` with JSON `{ "batch_size": int, "queue_timeout": float }` updates the runtime behavior.
 Standalone mode is still available by running `python admin_api.py`.
 
+## Building Cython extensions
+
+The postprocessing stage ships with an optional Cython implementation for
+better performance. To build the extension locally run:
+
+```bash
+pip install cython numpy
+python setup.py build_ext --inplace
+```
+
+If the compiled module is unavailable, the pure Python fallback will be used.
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+import numpy as np
+
+extensions = [
+    Extension(
+        name="utils.fast_postprocess",
+        sources=["utils/fast_postprocess.pyx"],
+        include_dirs=[np.get_include()],
+    )
+]
+
+setup(
+    ext_modules=cythonize(extensions, compiler_directives={"language_level": "3"}),
+)

--- a/utils/fast_postprocess.pyx
+++ b/utils/fast_postprocess.pyx
@@ -1,0 +1,35 @@
+# cython: language_level=3
+import numpy as np
+cimport numpy as np
+
+cdef int _collect_landmarks(float[:, :, :] kpts_xy, float[:, :] kpts_conf,
+                            float threshold,
+                            float[:, :] out_xy, float[:] out_conf) nogil:
+    cdef int num_kpts = kpts_xy.shape[1]
+    cdef int count = 0
+    cdef int kid
+    for kid in range(num_kpts):
+        if kpts_conf[0, kid] >= threshold:
+            out_xy[count, 0] = kpts_xy[0, kid, 0]
+            out_xy[count, 1] = kpts_xy[0, kid, 1]
+            out_conf[count] = kpts_conf[0, kid]
+            count += 1
+    return count
+
+
+def yolo_result2landmarks_array(np.ndarray[np.float32_t, ndim=3] kpts_xy not None,
+                                np.ndarray[np.float32_t, ndim=2] kpts_conf not None,
+                                float threshold=0.5):
+    cdef int num_kpts = kpts_xy.shape[1]
+    cdef np.ndarray[np.float32_t, ndim=2] out_xy = np.empty((num_kpts, 2), dtype=np.float32)
+    cdef np.ndarray[np.float32_t, ndim=1] out_conf = np.empty(num_kpts, dtype=np.float32)
+    cdef int count
+
+    count = _collect_landmarks(kpts_xy, kpts_conf, threshold, out_xy, out_conf)
+
+    cdef list result = []
+    cdef int i
+    for i in range(count):
+        result.append((<int>out_xy[i, 0], <int>out_xy[i, 1],
+                       round(float(out_conf[i]), 3)))
+    return result

--- a/utils/formatter.py
+++ b/utils/formatter.py
@@ -2,6 +2,7 @@ import numpy as np
 import cv2
 import json
 from utils.timing import timing_decorator
+from utils.landmarks import yolo_result2landmarks
 
 @timing_decorator("Preprocess")
 def preprocess_image(image_data):
@@ -16,12 +17,3 @@ def postprocess_result(result):
         skeletons.append({"id": i, "keypoints": landmarks})
     return json.dumps(skeletons)
 
-def yolo_result2landmarks(kpts):
-    kpts_xy = kpts[0].xy.cpu().numpy()
-    kpts_conf = kpts[0].conf.cpu().numpy()
-    num_kpts = kpts_xy.shape[1]
-    return [
-        (int(kpts_xy[0][kid][0]), int(kpts_xy[0][kid][1]),
-         round(float(kpts_conf[0][kid]), 3))
-        for kid in range(num_kpts) if kpts_conf[0][kid] >= 0.5
-    ]

--- a/utils/landmarks.py
+++ b/utils/landmarks.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+try:
+    from utils.fast_postprocess import yolo_result2landmarks_array as _fast_impl
+    HAS_FAST = True
+except Exception:  # pragma: no cover - fallback when extension not built
+    HAS_FAST = False
+
+
+def yolo_result2landmarks(kpts, threshold: float = 0.5):
+    """Convert keypoints to landmark tuples.
+
+    Parameters
+    ----------
+    kpts : object
+        Keypoints object from YOLO result.
+    threshold : float, optional
+        Confidence threshold, by default 0.5
+
+    Returns
+    -------
+    list[tuple[int, int, float]]
+        Filtered landmark list.
+    """
+    kpts_xy = kpts[0].xy.cpu().numpy()
+    kpts_conf = kpts[0].conf.cpu().numpy()
+    if HAS_FAST:
+        return _fast_impl(kpts_xy, kpts_conf, threshold)
+
+    num_kpts = kpts_xy.shape[1]
+    return [
+        (int(kpts_xy[0][kid][0]), int(kpts_xy[0][kid][1]),
+         round(float(kpts_conf[0][kid]), 3))
+        for kid in range(num_kpts) if kpts_conf[0][kid] >= threshold
+    ]

--- a/utils/postprocessor.py
+++ b/utils/postprocessor.py
@@ -1,6 +1,6 @@
 import json
-import numpy as np
 from utils.timing import timing_decorator
+from utils.landmarks import yolo_result2landmarks
 
 class Postprocessor:
     def process(self, result): raise NotImplementedError
@@ -10,16 +10,6 @@ class PosePostprocessor(Postprocessor):
     def process(self, result):
         skeletons = []
         for i, det in enumerate(result):
-            landmarks = self._yolo_result2landmarks(det.keypoints)
+            landmarks = yolo_result2landmarks(det.keypoints)
             skeletons.append({"id": i, "keypoints": landmarks})
         return json.dumps(skeletons)
-
-    def _yolo_result2landmarks(self, kpts):
-        kpts_xy = kpts[0].xy.cpu().numpy()
-        kpts_conf = kpts[0].conf.cpu().numpy()
-        num_kpts = kpts_xy.shape[1]
-        return [
-            (int(kpts_xy[0][kid][0]), int(kpts_xy[0][kid][1]),
-             round(float(kpts_conf[0][kid]), 3))
-            for kid in range(num_kpts) if kpts_conf[0][kid] >= 0.5
-        ]


### PR DESCRIPTION
## Summary
- speed up postprocessing by adding `utils.fast_postprocess` Cython module
- expose `yolo_result2landmarks` helper in `utils.landmarks`
- use accelerated implementation from postprocessor and formatter
- document build instructions for the Cython extension
- add `.gitignore` and build script

## Testing
- `python setup.py build_ext --inplace`
- `python - <<'PY'
import numpy as np
from utils.fast_postprocess import yolo_result2landmarks_array
xy = np.arange(1*5*2, dtype=np.float32).reshape(1,5,2)
conf = np.linspace(0.1, 0.9, 5, dtype=np.float32).reshape(1,5)
print(yolo_result2landmarks_array(xy, conf, 0.5))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68480bd49a04833199a871a7cee87093