### PR TITLE
Add batch logging and timestamps

### DIFF
--- a/core/request_wrapper.py
+++ b/core/request_wrapper.py
@@ -6,4 +6,6 @@ class RequestWrapper:
         self.frame = frame
         self.result_queue = queue.Queue()
         self.enqueue_time = time.time()
+        self.receive_ts = time.strftime("%Y-%m-%d %H:%M:%S")
         self.logger = None  # 在外部由 PoseService 注入
+        self.batch_id = None

--- a/processor/batch_processor.py
+++ b/processor/batch_processor.py
@@ -10,6 +10,7 @@ class BatchProcessor:
         self.queue = queue
         self.config = config
         self.logger = get_logger(__name__)
+        self.batch_counter = 0
 
     def run_forever(self):
         while True:
@@ -43,12 +44,16 @@ class BatchProcessor:
         return wrappers
 
     def _run_inference(self, wrappers):
+        self.batch_counter += 1
+        current_batch_id = self.batch_counter
         for wrapper in wrappers:
+            wrapper.batch_id = current_batch_id
             wrapper.logger.set_mark("infer_start")
             wrapper.logger.update({
                 "batch_size": len(wrappers),
                 "trigger_type": self.trigger_type,
-                "trigger_time": self.trigger_time
+                "trigger_time": self.trigger_time,
+                "batch_id": current_batch_id,
             })
 
         batch_images = [w.frame for w in wrappers]

--- a/service/pose_service.py
+++ b/service/pose_service.py
@@ -41,6 +41,7 @@ class PoseDetectionService(pose_pb2_grpc.MirrorServicer):
 
             wrapper = RequestWrapper(frame)
             wrapper.logger = logger  # 將 logger 傳入 wrapper
+            logger.set("receive_ts", wrapper.receive_ts)
             self.queue.put(wrapper)
             self.logger.info(
                 "Request %s enqueued from %s | size=%d",
@@ -57,5 +58,5 @@ class PoseDetectionService(pose_pb2_grpc.MirrorServicer):
                 self.logger.error("Timeout waiting for result for %s: %s", logger.request_id, e)
                 processed = ""
 
-            #logger.write()
+            wrapper.logger.write()
             return pose_pb2.FrameResponse(skeletons=processed)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -19,7 +19,8 @@ LOG_PATH = "logs/request_trace.csv"
 FIELDNAMES = [
     "request_id", "client_ip", "batch_size",
     "wait_ms", "trigger_type", "trigger_time_ms",
-    "inference_ms", "postprocess_ms", "total_ms"
+    "inference_ms", "postprocess_ms", "total_ms",
+    "receive_ts", "batch_id"
 ]
 
 class RequestLogger:
@@ -33,6 +34,8 @@ class RequestLogger:
             "inference_ms": 0,
             "postprocess_ms": 0,
             "total_ms": 0,
+            "receive_ts": "",
+            "batch_id": None,
         }
         self.time_ref = {}
         self._start_total = time.time()


### PR DESCRIPTION
## Summary
- track incoming timestamp in RequestWrapper
- log batch details per inference batch
- support receive_ts and batch_id in RequestLogger
- log fields for each request in PoseDetectionService

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbf3c8acc83318bdfb1dc9a217a62