### PR TITLE
Add preprocess metric field and fix trigger time units

### DIFF
--- a/processor/batch_processor.py
+++ b/processor/batch_processor.py
@@ -52,7 +52,7 @@ class BatchProcessor:
             wrapper.logger.update({
                 "batch_size": len(wrappers),
                 "trigger_type": self.trigger_type,
-                "trigger_time": self.trigger_time,
+                "trigger_time_ms": self.trigger_time * 1000,
                 "batch_id": current_batch_id,
             })
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -19,7 +19,7 @@ LOG_PATH = "logs/request_trace.csv"
 FIELDNAMES = [
     "request_id", "client_ip", "batch_size",
     "wait_ms", "trigger_type", "trigger_time_ms",
-    "inference_ms", "postprocess_ms", "total_ms",
+    "inference_ms", "preprocess_ms", "postprocess_ms", "total_ms",
     "receive_ts", "batch_id"
 ]
 
@@ -32,6 +32,7 @@ class RequestLogger:
             "wait_ms": 0,
             "trigger_time_ms": 0,
             "inference_ms": 0,
+            "preprocess_ms": 0,
             "postprocess_ms": 0,
             "total_ms": 0,
             "receive_ts": "",


### PR DESCRIPTION
## Summary
- include `preprocess_ms` as a recorded metric
- convert trigger time to milliseconds when logging batch processor events

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dc6b979b08331b85b710f67c2442c