### PR TITLE
Enable server self-test for maximum RPS

### DIFF
--- a/admin_api.py
+++ b/admin_api.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI, HTTPException
 from pydantic.v1 import BaseModel
 from batch_config import global_batch_config
 from typing import Union
+from metrics.max_load_estimator import MaxLoadEstimator
+from config import settings
 app = FastAPI()
 
 class BatchConfigUpdate(BaseModel):
@@ -19,6 +21,24 @@ def update_batch_config(update: BatchConfigUpdate):
         raise HTTPException(status_code=400, detail="No parameters provided")
     global_batch_config.update(update.batch_size, update.queue_timeout)
     return global_batch_config.as_dict()
+
+
+class EstimateRequest(BaseModel):
+    max_rps: int = 50
+    step: int = 5
+    duration: float = 5.0
+
+
+@app.post("/system/estimate_throughput")
+def estimate_throughput(req: EstimateRequest):
+    estimator = MaxLoadEstimator(
+        target=f"localhost:{settings.gRPC_port}",
+        duration=req.duration,
+        step=req.step,
+        max_rps=req.max_rps,
+    )
+    max_rps = estimator.estimate()
+    return {"max_rps": max_rps}
 
 if __name__ == "__main__":
     import uvicorn

--- a/main.py
+++ b/main.py
@@ -53,8 +53,8 @@ def serve():
 if __name__ == "__main__":
     #----------服務註冊位置-------------------
     # metrics/registry.py（繼續）
-    monitorRegistry.register(name="rps",instance= RPSMonitor(interval=1.0))
-    #monitorRegistry.register("global_queue_size", QueueSizeMonitor(globalRequestQueue, sample_interval=0.005, report_interval=1.0))
+    monitorRegistry.register(name="rps", instance=RPSMonitor(interval=1.0))
+    monitorRegistry.register(name="queue", instance=QueueSizeMonitor(globalRequestQueue, sample_interval=0.005, report_interval=1.0))
     monitorRegistry.start_all()
     #----------------------------------------
     serve()

--- a/metrics/max_load_estimator.py
+++ b/metrics/max_load_estimator.py
@@ -1,0 +1,42 @@
+import time
+import grpc
+from metrics.registry import monitorRegistry
+import pose_pb2
+import pose_pb2_grpc
+
+
+class MaxLoadEstimator:
+    def __init__(self, target="localhost:50052", duration=5.0, step=5, max_rps=50):
+        self.target = target
+        self.duration = duration
+        self.step = step
+        self.max_rps = max_rps
+
+    def _run_step(self, stub, rps):
+        interval = 1.0 / rps
+        end = time.time() + self.duration
+        request = pose_pb2.FrameRequest(image_data=b"")
+        while time.time() < end:
+            stub.SkeletonFrame(request)
+            time.sleep(interval)
+
+    def estimate(self):
+        channel = grpc.insecure_channel(self.target)
+        stub = pose_pb2_grpc.MirrorStub(channel)
+
+        queue_monitor = monitorRegistry.get("queue")
+        if queue_monitor is None:
+            raise RuntimeError("QueueSizeMonitor is not registered")
+
+        best_rps = 0
+        current = self.step
+        while current <= self.max_rps:
+            self._run_step(stub, current)
+            time.sleep(queue_monitor.report_interval)
+            stats = queue_monitor.get_recent_stats()
+            if not stats or stats["zero_ratio"] < 80:
+                break
+            best_rps = current
+            current += self.step
+
+        return best_rps

--- a/metrics/queue_monitor.py
+++ b/metrics/queue_monitor.py
@@ -76,3 +76,24 @@ class QueueSizeMonitor:
             with open(self.csv_log_path, "a", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow([timestamp_str, avg, max_val, min_val, latest, zero_count, round(zero_ratio, 2)])
+
+    def get_recent_stats(self):
+        now = time.time()
+        cutoff = now - self.report_interval
+        with self.lock:
+            recent = [size for ts, size in self.samples if ts >= cutoff]
+        if not recent:
+            return None
+        avg = sum(recent) / len(recent)
+        max_val = max(recent)
+        min_val = min(recent)
+        latest = recent[-1]
+        zero_count = sum(1 for s in recent if s == 0)
+        zero_ratio = zero_count / len(recent) * 100
+        return {
+            "avg": avg,
+            "max": max_val,
+            "min": min_val,
+            "latest": latest,
+            "zero_ratio": zero_ratio,
+        }

--- a/metrics/rps_monitor.py
+++ b/metrics/rps_monitor.py
@@ -8,6 +8,7 @@ class RPSMonitor:
     def __init__(self, interval=1.0, csv_log_path="logs/rps_stats.csv"):
         self.interval = interval
         self.counter = 0
+        self.last_rps = 0
         self.lock = threading.Lock()
         self.csv_log_path = csv_log_path
         self._init_log()
@@ -30,10 +31,15 @@ class RPSMonitor:
                 with self.lock:
                     rps = self.counter
                     self.counter = 0
+                    self.last_rps = rps
                 timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
                 logging.info("[Monitor] Current time = %s, rps=%s", timestamp, rps)
                 with open(self.csv_log_path, "a", newline="") as f:
                     writer = csv.writer(f)
                     writer.writerow([timestamp, rps])
         threading.Thread(target=loop, daemon=True).start()
+
+    def get_last_rps(self):
+        with self.lock:
+            return self.last_rps
 


### PR DESCRIPTION
## Summary
- enable queue monitoring by default in `main.py`
- expose new `MaxLoadEstimator` for internal load tests
- extend monitors with query helpers
- add admin API endpoint `/system/estimate_throughput`

## Testing
- `python -m py_compile metrics/max_load_estimator.py`
- `python -m py_compile metrics/queue_monitor.py`
- `python -m py_compile metrics/rps_monitor.py`
- `python -m py_compile admin_api.py`
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd5117da08331843f9362174dc0a0