### PR TITLE
Add Prometheus exporter for monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ python setup.py build_ext --inplace
 
 If the compiled module is unavailable, the pure Python fallback will be used.
 
+## Metrics Export
+
+The server exposes monitoring metrics for Prometheus on port `8001`. Install
+`prometheus_client` and run the application normally. Prometheus can scrape
+`http://<host>:8001/metrics` to collect queue size and request rate statistics.
+

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from infra.request_queue import globalRequestQueue
 from metrics.registry import monitorRegistry
 from metrics.rps_monitor import RPSMonitor
 from metrics.queue_monitor import QueueSizeMonitor
+from metrics.prometheus_exporter import PrometheusExporter
 
 #--------------------------------
 
@@ -55,6 +56,7 @@ if __name__ == "__main__":
     # metrics/registry.py（繼續）
     monitorRegistry.register(name="rps", instance=RPSMonitor(interval=1.0))
     monitorRegistry.register(name="queue", instance=QueueSizeMonitor(globalRequestQueue, sample_interval=0.005, report_interval=1.0))
+    monitorRegistry.register(name="prometheus", instance=PrometheusExporter(port=8001))
     monitorRegistry.start_all()
     #----------------------------------------
     serve()

--- a/metrics/prometheus_exporter.py
+++ b/metrics/prometheus_exporter.py
@@ -1,0 +1,28 @@
+import logging
+from prometheus_client import start_http_server, Gauge
+
+class PrometheusExporter:
+    def __init__(self, port: int = 8001):
+        self.port = port
+        self.queue_avg = Gauge('queue_size_avg', 'Average queue size over the last interval')
+        self.queue_max = Gauge('queue_size_max', 'Maximum queue size over the last interval')
+        self.queue_min = Gauge('queue_size_min', 'Minimum queue size over the last interval')
+        self.queue_latest = Gauge('queue_size_latest', 'Latest queue size sample')
+        self.queue_zero_ratio = Gauge('queue_zero_ratio', 'Percentage of zero-size queue samples')
+        self.rps = Gauge('requests_per_second', 'Number of requests processed per second')
+        start_http_server(self.port)
+        logging.getLogger(__name__).info('Prometheus exporter running on port %s', self.port)
+
+    def update_queue(self, stats: dict):
+        """Update queue related metrics with a stats dictionary."""
+        if not stats:
+            return
+        self.queue_avg.set(stats.get('avg', 0))
+        self.queue_max.set(stats.get('max', 0))
+        self.queue_min.set(stats.get('min', 0))
+        self.queue_latest.set(stats.get('latest', 0))
+        self.queue_zero_ratio.set(stats.get('zero_ratio', 0))
+
+    def update_rps(self, rps: float):
+        """Update the RPS metric."""
+        self.rps.set(rps)

--- a/metrics/queue_monitor.py
+++ b/metrics/queue_monitor.py
@@ -3,6 +3,7 @@ import time
 import os
 import csv
 import logging
+from metrics.registry import monitorRegistry
 from collections import deque
 from datetime import datetime
 
@@ -76,6 +77,16 @@ class QueueSizeMonitor:
             with open(self.csv_log_path, "a", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow([timestamp_str, avg, max_val, min_val, latest, zero_count, round(zero_ratio, 2)])
+
+            prometheus = monitorRegistry.get("prometheus")
+            if prometheus:
+                prometheus.update_queue({
+                    "avg": avg,
+                    "max": max_val,
+                    "min": min_val,
+                    "latest": latest,
+                    "zero_ratio": zero_ratio,
+                })
 
     def get_recent_stats(self):
         now = time.time()

--- a/metrics/registry.py
+++ b/metrics/registry.py
@@ -21,5 +21,9 @@ class MonitorRegistry:
     def queue_monitor(self):
         return self._registry.get("queue_monitor")
 
+    @property
+    def prometheus_exporter(self):
+        return self._registry.get("prometheus")
+
 # metrics/registry.py（繼續）
 monitorRegistry = MonitorRegistry()

--- a/metrics/rps_monitor.py
+++ b/metrics/rps_monitor.py
@@ -3,6 +3,7 @@ import time
 import logging
 import os
 import csv
+from metrics.registry import monitorRegistry
 
 class RPSMonitor:
     def __init__(self, interval=1.0, csv_log_path="logs/rps_stats.csv"):
@@ -37,6 +38,9 @@ class RPSMonitor:
                 with open(self.csv_log_path, "a", newline="") as f:
                     writer = csv.writer(f)
                     writer.writerow([timestamp, rps])
+                prometheus = monitorRegistry.get("prometheus")
+                if prometheus:
+                    prometheus.update_rps(rps)
         threading.Thread(target=loop, daemon=True).start()
 
     def get_last_rps(self):


### PR DESCRIPTION
## Summary
- publish queue size and RPS metrics to Prometheus
- expose metrics via `PrometheusExporter` on port 8001
- update monitors to push their stats
- document how to use Prometheus metrics

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cce36cfc483319ce2c9319d82cdab