### PR TITLE
Add completion request monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ If the compiled module is unavailable, the pure Python fallback will be used.
 
 The server exposes monitoring metrics for Prometheus on port `8001`. Install
 `prometheus_client` and run the application normally. Prometheus can scrape
-`http://<host>:8001/metrics` to collect queue size and request rate statistics.
+`http://<host>:8001/metrics` to collect queue size, request rate, and completed
+request statistics.
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from metrics import registry
 from infra.request_queue import globalRequestQueue
 from metrics.registry import monitorRegistry
 from metrics.rps_monitor import RPSMonitor
+from metrics.completion_monitor import CompletionMonitor
 from metrics.queue_monitor import QueueSizeMonitor
 from metrics.prometheus_exporter import PrometheusExporter
 
@@ -55,6 +56,7 @@ if __name__ == "__main__":
     #----------服務註冊位置-------------------
     # metrics/registry.py（繼續）
     monitorRegistry.register(name="rps", instance=RPSMonitor(interval=1.0))
+    monitorRegistry.register(name="completion", instance=CompletionMonitor(interval=1.0))
     monitorRegistry.register(name="queue", instance=QueueSizeMonitor(globalRequestQueue, sample_interval=0.005, report_interval=1.0))
     monitorRegistry.register(name="prometheus", instance=PrometheusExporter(port=8001))
     monitorRegistry.start_all()

--- a/metrics/completion_monitor.py
+++ b/metrics/completion_monitor.py
@@ -1,0 +1,48 @@
+import threading
+import time
+import logging
+import os
+import csv
+from metrics.registry import monitorRegistry
+
+class CompletionMonitor:
+    def __init__(self, interval=1.0, csv_log_path="logs/completion_stats.csv"):
+        self.interval = interval
+        self.counter = 0
+        self.last_completed = 0
+        self.lock = threading.Lock()
+        self.csv_log_path = csv_log_path
+        self._init_log()
+
+    def _init_log(self):
+        os.makedirs(os.path.dirname(self.csv_log_path), exist_ok=True)
+        if not os.path.exists(self.csv_log_path):
+            with open(self.csv_log_path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["timestamp", "completed"])
+
+    def increment(self):
+        with self.lock:
+            self.counter += 1
+
+    def start(self):
+        def loop():
+            while True:
+                time.sleep(self.interval)
+                with self.lock:
+                    completed = self.counter
+                    self.counter = 0
+                    self.last_completed = completed
+                timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+                logging.info("[Monitor] Current time = %s, completed=%s", timestamp, completed)
+                with open(self.csv_log_path, "a", newline="") as f:
+                    writer = csv.writer(f)
+                    writer.writerow([timestamp, completed])
+                prometheus = monitorRegistry.get("prometheus")
+                if prometheus:
+                    prometheus.update_completed_rps(completed)
+        threading.Thread(target=loop, daemon=True).start()
+
+    def get_last_completed(self):
+        with self.lock:
+            return self.last_completed

--- a/metrics/prometheus_exporter.py
+++ b/metrics/prometheus_exporter.py
@@ -10,6 +10,7 @@ class PrometheusExporter:
         self.queue_latest = Gauge('queue_size_latest', 'Latest queue size sample')
         self.queue_zero_ratio = Gauge('queue_zero_ratio', 'Percentage of zero-size queue samples')
         self.rps = Gauge('requests_per_second', 'Number of requests processed per second')
+        self.completed_rps = Gauge('completed_requests_per_second', 'Number of requests completed per second')
         start_http_server(self.port)
         logging.getLogger(__name__).info('Prometheus exporter running on port %s', self.port)
 
@@ -26,3 +27,7 @@ class PrometheusExporter:
     def update_rps(self, rps: float):
         """Update the RPS metric."""
         self.rps.set(rps)
+
+    def update_completed_rps(self, rps: float):
+        """Update the completed requests per second metric."""
+        self.completed_rps.set(rps)

--- a/metrics/registry.py
+++ b/metrics/registry.py
@@ -25,5 +25,9 @@ class MonitorRegistry:
     def prometheus_exporter(self):
         return self._registry.get("prometheus")
 
+    @property
+    def completion_monitor(self):
+        return self._registry.get("completion")
+
 # metrics/registry.py（繼續）
 monitorRegistry = MonitorRegistry()

--- a/service/pose_service.py
+++ b/service/pose_service.py
@@ -59,4 +59,9 @@ class PoseDetectionService(pose_pb2_grpc.MirrorServicer):
                 processed = ""
 
             wrapper.logger.write()
+
+            completion = monitorRegistry.get("completion")
+            if completion:
+                completion.increment()
+
             return pose_pb2.FrameResponse(skeletons=processed)

--- a/service/pose_service_no_batch.py
+++ b/service/pose_service_no_batch.py
@@ -42,4 +42,9 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
                 processed = self.postprocessor.process(result)
 
             logger.write()
+
+            completion = monitorRegistry.get("completion")
+            if completion:
+                completion.increment()
+
             return pose_pb2.FrameResponse(skeletons=processed)


### PR DESCRIPTION
## Summary
- track how many requests complete each second
- expose completed requests metric via Prometheus
- increment completion counter when returning responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cd02f14588331904b9d07249a7b4c