### PR TITLE
Allow running without prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ If the compiled module is unavailable, the pure Python fallback will be used.
 
 ## Metrics Export
 
-The server exposes monitoring metrics for Prometheus on port `8001`. Install
-`prometheus_client` and run the application normally. Prometheus can scrape
-`http://<host>:8001/metrics` to collect queue size, request rate, and completed
-request statistics.
+The server exposes monitoring metrics for Prometheus on port `8001`. If
+`prometheus_client` is installed, run the application normally and Prometheus
+can scrape `http://<host>:8001/metrics` to collect queue size, request rate, and
+completed request statistics.  If the library is missing or the metrics server
+fails to start, the application continues to run without exporting metrics.
 

--- a/metrics/prometheus_exporter.py
+++ b/metrics/prometheus_exporter.py
@@ -1,22 +1,64 @@
 import logging
-from prometheus_client import start_http_server, Gauge
+
+try:
+    from prometheus_client import start_http_server, Gauge
+except Exception as e:  # pragma: no cover - best effort import
+    start_http_server = None
+    Gauge = None
+    logging.getLogger(__name__).warning(
+        "Prometheus client unavailable: %s. Metrics will be disabled.", e
+    )
 
 class PrometheusExporter:
+    """Expose server metrics for Prometheus if possible."""
+
     def __init__(self, port: int = 8001):
         self.port = port
-        self.queue_avg = Gauge('queue_size_avg', 'Average queue size over the last interval')
-        self.queue_max = Gauge('queue_size_max', 'Maximum queue size over the last interval')
-        self.queue_min = Gauge('queue_size_min', 'Minimum queue size over the last interval')
-        self.queue_latest = Gauge('queue_size_latest', 'Latest queue size sample')
-        self.queue_zero_ratio = Gauge('queue_zero_ratio', 'Percentage of zero-size queue samples')
-        self.rps = Gauge('requests_per_second', 'Number of requests processed per second')
-        self.completed_rps = Gauge('completed_requests_per_second', 'Number of requests completed per second')
-        start_http_server(self.port)
-        logging.getLogger(__name__).info('Prometheus exporter running on port %s', self.port)
+        self.enabled = False
+
+        if Gauge is None or start_http_server is None:
+            logging.getLogger(__name__).warning(
+                "Prometheus exporter disabled because prometheus_client is missing"
+            )
+            return
+
+        try:
+            self.queue_avg = Gauge(
+                "queue_size_avg", "Average queue size over the last interval"
+            )
+            self.queue_max = Gauge(
+                "queue_size_max", "Maximum queue size over the last interval"
+            )
+            self.queue_min = Gauge(
+                "queue_size_min", "Minimum queue size over the last interval"
+            )
+            self.queue_latest = Gauge(
+                "queue_size_latest", "Latest queue size sample"
+            )
+            self.queue_zero_ratio = Gauge(
+                "queue_zero_ratio", "Percentage of zero-size queue samples"
+            )
+            self.rps = Gauge(
+                "requests_per_second", "Number of requests processed per second"
+            )
+            self.completed_rps = Gauge(
+                "completed_requests_per_second",
+                "Number of requests completed per second",
+            )
+
+            start_http_server(self.port)
+            self.enabled = True
+            logging.getLogger(__name__).info(
+                "Prometheus exporter running on port %s", self.port
+            )
+        except Exception as e:  # pragma: no cover - best effort start
+            logging.getLogger(__name__).warning(
+                "Failed to start Prometheus exporter: %s", e
+            )
 
     def update_queue(self, stats: dict):
         """Update queue related metrics with a stats dictionary."""
-        if not stats:
+        if not self.enabled or not stats:
             return
         self.queue_avg.set(stats.get('avg', 0))
         self.queue_max.set(stats.get('max', 0))
@@ -26,8 +68,10 @@ class PrometheusExporter:
 
     def update_rps(self, rps: float):
         """Update the RPS metric."""
-        self.rps.set(rps)
+        if self.enabled:
+            self.rps.set(rps)
 
     def update_completed_rps(self, rps: float):
         """Update the completed requests per second metric."""
-        self.completed_rps.set(rps)
+        if self.enabled:
+            self.completed_rps.set(rps)


### PR DESCRIPTION
## Summary
- avoid crashing when `prometheus_client` is missing or the exporter fails to start
- make metric updates conditional on exporter availability
- document optional Prometheus support in README

## Testing
- `python - <<'EOF'
import subprocess, py_compile
files = subprocess.check_output(['git','ls-files','*.py']).decode().splitlines()
for f in files:
    py_compile.compile(f, doraise=True)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685cd337dd548331890a59a918c6ea28