### PR TITLE
Add metrics merge utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ can scrape `http://<host>:8001/metrics` to collect queue size, request rate, and
 completed request statistics.  If the library is missing or the metrics server
 fails to start, the application continues to run without exporting metrics.
 
+
+Metrics from the queue, completion, and RPS monitors are written as separate CSV
+files under `logs/`. Run `python utils/merge_metrics.py` to combine these into
+`logs/merged_stats.csv` for easier analysis.

--- a/utils/merge_metrics.py
+++ b/utils/merge_metrics.py
@@ -1,0 +1,71 @@
+import argparse
+import csv
+
+
+def load_by_timestamp(path):
+    data = {}
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ts = row.get("timestamp")
+            if ts is not None:
+                data[ts] = row
+    return data
+
+
+def merge_metrics(rps_path, completion_path, queue_path):
+    rps = load_by_timestamp(rps_path)
+    completion = load_by_timestamp(completion_path)
+    queue = load_by_timestamp(queue_path)
+
+    timestamps = set(rps) | set(completion) | set(queue)
+    rows = []
+    for ts in sorted(timestamps):
+        merged = {
+            "timestamp": ts,
+            "rps": rps.get(ts, {}).get("rps"),
+            "completed": completion.get(ts, {}).get("completed"),
+            "avg": queue.get(ts, {}).get("avg"),
+            "max": queue.get(ts, {}).get("max"),
+            "min": queue.get(ts, {}).get("min"),
+            "latest": queue.get(ts, {}).get("latest"),
+            "zero_count": queue.get(ts, {}).get("zero_count"),
+            "zero_ratio": queue.get(ts, {}).get("zero_ratio"),
+        }
+        rows.append(merged)
+    return rows
+
+
+def write_csv(rows, output_path):
+    fieldnames = [
+        "timestamp",
+        "rps",
+        "completed",
+        "avg",
+        "max",
+        "min",
+        "latest",
+        "zero_count",
+        "zero_ratio",
+    ]
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge metric CSV files by timestamp")
+    parser.add_argument("--rps-path", default="logs/rps_stats.csv")
+    parser.add_argument("--completion-path", default="logs/completion_stats.csv")
+    parser.add_argument("--queue-path", default="logs/queue_stats.csv")
+    parser.add_argument("--output-path", default="logs/merged_stats.csv")
+    args = parser.parse_args()
+
+    rows = merge_metrics(args.rps_path, args.completion_path, args.queue_path)
+    write_csv(rows, args.output_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `utils/merge_metrics.py` for merging metric CSV files
- document how to use the merge script in the README

## Testing
- `python -m py_compile utils/merge_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68610deec3a883318c07295f179b6532