### PR TITLE
Fix locking for single frame processor

### DIFF
--- a/processor/single_processor.py
+++ b/processor/single_processor.py
@@ -1,4 +1,4 @@
-from ultralytics.utils import ThreadingLocked
+import threading
 
 
 class SingleFrameProcessor:
@@ -6,7 +6,7 @@ class SingleFrameProcessor:
 
     def __init__(self, worker):
         self.worker = worker
-        self._lock = ThreadingLocked()
+        self._lock = threading.Lock()
 
     def predict(self, frame):
         """Run prediction for a single frame in a thread-safe manner."""


### PR DESCRIPTION
## Summary
- use Python standard `threading.Lock` rather than ultralytics utility

## Testing
- `python -c "import processor.single_processor; print('Imported single_processor successfully')"`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'ultralytics')*

------
https://chatgpt.com/codex/tasks/task_e_686121518b4c8331a90462f64a9d000a