### PR TITLE
Add millisecond precision to request timestamps

### DIFF
--- a/core/request_wrapper.py
+++ b/core/request_wrapper.py
@@ -1,11 +1,12 @@
 import time
 import queue
+from datetime import datetime
 
 class RequestWrapper:
     def __init__(self, frame):
         self.frame = frame
         self.result_queue = queue.Queue()
         self.enqueue_time = time.time()
-        self.receive_ts = time.strftime("%Y-%m-%d %H:%M:%S")
+        self.receive_ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         self.logger = None  # 在外部由 PoseService 注入
         self.batch_id = None

--- a/service/pose_service_no_batch.py
+++ b/service/pose_service_no_batch.py
@@ -1,5 +1,6 @@
 import time
 import queue
+from datetime import datetime
 import pose_pb2_grpc
 import pose_pb2
 from model.batch_worker import BatchWorker
@@ -32,7 +33,7 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
         with logger_context() as logger:
             logger.set_mark("start")
             logger.set("client_ip", client_ip)
-            logger.set("receive_ts", time.strftime("%Y-%m-%d %H:%M:%S"))
+            logger.set("receive_ts", datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3])
             logger.update({
                 "batch_size": 1,
                 "trigger_type": "single",

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,6 +4,7 @@ import os
 import logging
 from contextlib import contextmanager
 from uuid import uuid4
+from datetime import datetime
 
 # basic application logging configuration
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
@@ -37,7 +38,7 @@ class RequestLogger:
             "total_ms": 0,
             "receive_ts": "",
             "batch_id": None,
-            "start_ts": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "start_ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
             "end_ts": "",
         }
         self.time_ref = {}
@@ -77,7 +78,7 @@ class RequestLogger:
 
     def write(self):
         self.fields["total_ms"] = (time.time() - self._start_total) * 1000
-        self.fields["end_ts"] = time.strftime("%Y-%m-%d %H:%M:%S")
+        self.fields["end_ts"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
         is_new = not os.path.exists(LOG_PATH)
         with open(LOG_PATH, "a", newline="") as f:


### PR DESCRIPTION
## Summary
- include milliseconds in `start_ts` and `end_ts`
- add milliseconds to `receive_ts` when wrapping requests

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68631d52656c8331a88dcae0fe223ac7