### PR TITLE
Add deployment guide for Docker, Kubernetes and Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ fails to start, the application continues to run without exporting metrics.
 Metrics from the queue, completion, and RPS monitors are written as separate CSV
 files under an automatically created `logs/` directory. Run `python metrics/merge_metrics.py`
 to combine these into `logs/merged_stats.csv` for easier analysis.
+
+## Docker and Kubernetes
+
+See [docs/deployment_guide.md](docs/deployment_guide.md) for instructions on building the Docker image, example Kubernetes manifests, and enabling Prometheus scraping.

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -1,0 +1,73 @@
+# Docker & Kubernetes Deployment
+
+This guide shows how to build the container image and deploy the server on Kubernetes. It also covers configuring Prometheus to scrape metrics.
+
+## Building the Docker image
+
+Run the following command from the project root. The repository contains a `Dockerfile` that installs all dependencies and starts the gRPC server.
+
+```bash
+docker build -t infer-server:latest .
+```
+
+The resulting image can be pushed to your registry and referenced by Kubernetes manifests.
+
+## Example Deployment YAML
+
+Below is a minimal `Deployment` that runs the server and a corresponding `Service` that exposes both gRPC and metrics ports.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infer-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: infer-server
+  template:
+    metadata:
+      labels:
+        app: infer-server
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8001"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+      - name: server
+        image: infer-server:latest
+        args: ["python", "main.py"]
+        ports:
+        - containerPort: 50052  # gRPC
+        - containerPort: 8000   # admin API
+        - containerPort: 8001   # Prometheus metrics
+```
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: infer-server
+spec:
+  selector:
+    app: infer-server
+  ports:
+  - name: grpc
+    port: 50052
+    targetPort: 50052
+  - name: admin
+    port: 8000
+    targetPort: 8000
+  - name: metrics
+    port: 8001
+    targetPort: 8001
+```
+
+Apply the manifests with `kubectl apply -f <file>.yaml` or create them directly using `kubectl create` commands.
+
+## Prometheus discovery
+
+Prometheus discovers the metrics endpoint through the annotations added to the pod template above. When `prometheus.io/scrape: "true"` is present, Prometheus scrapes `http://<pod_ip>:8001/metrics` automatically. Ensure your Prometheus configuration includes Kubernetes service discovery so that the scraper finds pods with this annotation.


### PR DESCRIPTION
## Summary
- document how to build the Docker image
- add example Kubernetes Deployment/Service YAML
- explain Prometheus discovery via annotations
- link the new doc from README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68707985713c833189e71998f179353a