### PR TITLE
feat: drop overdue requests

### DIFF
--- a/core/request_dropper.py
+++ b/core/request_dropper.py
@@ -1,0 +1,43 @@
+import time
+from typing import Callable, Any
+
+from config import settings
+
+
+class RequestTimeoutError(Exception):
+    """Raised when a request has waited in queue too long."""
+
+
+class RequestDropper:
+    """Encapsulates logic for dropping requests that exceed a wait timeout.
+
+    The dropper is intended to be used by higher level services.  They only
+    need to ``mark`` the arrival time of a request and then execute the
+    desired function through ``run``.  Any waiting logic is handled here so
+    that the request pipeline remains clean.
+    """
+
+    def __init__(self, max_wait: float | None = None):
+        self.max_wait = max_wait if max_wait is not None else settings.queue_timeout
+
+    def mark(self) -> float:
+        """Return a timestamp marking the enqueue time of a request."""
+        return time.time()
+
+    def run(self, func: Callable[..., Any], enqueue_time: float, *args, **kwargs):
+        """Execute ``func`` if the request has not timed out.
+
+        ``func`` should accept a ``timeout`` keyword argument controlling how
+        long it is willing to wait for required resources.  This allows the
+        dropper to ensure GPU resources are not used for overdue requests.
+        """
+        elapsed = time.time() - enqueue_time
+        remaining = self.max_wait - elapsed
+        if remaining <= 0:
+            raise RequestTimeoutError("request exceeded max wait time")
+
+        kwargs.setdefault("timeout", remaining)
+        try:
+            return func(*args, **kwargs)
+        except TimeoutError as e:  # Propagate as request-level timeout
+            raise RequestTimeoutError("request exceeded max wait time") from e

--- a/processor/single_processor.py
+++ b/processor/single_processor.py
@@ -8,7 +8,20 @@ class SingleFrameProcessor:
         self.worker = worker
         self._lock = threading.Lock()
 
-    def predict(self, frame):
-        """Run prediction for a single frame in a thread-safe manner."""
-        with self._lock:
+    def predict(self, frame, timeout: float | None = None):
+        """Run prediction for a single frame in a thread-safe manner.
+
+        An optional ``timeout`` can be provided to limit how long the call
+        waits to acquire the internal lock.  If the lock cannot be acquired
+        within the timeout a ``TimeoutError`` will be raised and no GPU work
+        will be scheduled.
+        """
+        acquired = (
+            self._lock.acquire(timeout=timeout) if timeout is not None else self._lock.acquire()
+        )
+        if not acquired:
+            raise TimeoutError("timed out waiting for the worker lock")
+        try:
             return self.worker.predict([frame])[0]
+        finally:
+            self._lock.release()

--- a/service/pose_service_no_batch.py
+++ b/service/pose_service_no_batch.py
@@ -1,5 +1,3 @@
-import time
-import queue
 from datetime import datetime
 from proto import pose_pb2_grpc
 from proto import pose_pb2
@@ -10,6 +8,9 @@ from processor.preprocessor import PosePreprocessor
 from processor.postprocessor import PosePostprocessor
 from metrics.registry import monitorRegistry
 from infra.request_queue import RequestQueue
+from core.request_dropper import RequestDropper, RequestTimeoutError
+
+
 class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
     """gRPC service that processes each request without batching."""
 
@@ -18,6 +19,7 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
         self.preprocessor = PosePreprocessor()
         self.postprocessor = PosePostprocessor()
         self.processor = SingleFrameProcessor(self.worker)
+        self.dropper = RequestDropper()
         self.logger = get_logger(__name__)
         self.queue = request_queue
 
@@ -28,6 +30,7 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
 
         # enqueue request for queue size monitoring
         self.queue.enqueue(1)
+        enqueue_time = self.dropper.mark()
 
         client_ip = context.peer().split(":")[-1].replace("ipv4/", "")
         with logger_context() as logger:
@@ -43,11 +46,15 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
             with logger.phase("preprocess"):
                 frame = self.preprocessor.process(request.image_data)
 
-            with logger.phase("inference"):
-                result = self.processor.predict(frame)
-
-            with logger.phase("postprocess"):
-                processed = self.postprocessor.process(result)
+            try:
+                with logger.phase("inference"):
+                    result = self.dropper.run(self.processor.predict, enqueue_time, frame)
+            except RequestTimeoutError:
+                processed = ""
+                logger.update({"dropped": True})
+            else:
+                with logger.phase("postprocess"):
+                    processed = self.postprocessor.process(result)
 
             logger.write()
 


### PR DESCRIPTION
## Summary
- drop requests that wait too long before inference
- add RequestDropper helper and timeout aware SingleFrameProcessor
- integrate dropping logic into pose_service_no_batch

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | tr -d '\0' | xargs python -m py_compile)`
- `python -m pytest` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689197f569308331afcd3bb01eeb3275