### PR TITLE
Add CRD definitions for HA services and resources

### DIFF
--- a/crds/nodestatuses.yaml
+++ b/crds/nodestatuses.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodestatuses.ha.example.com
+spec:
+  group: ha.example.com
+  scope: Namespaced
+  names:
+    plural: nodestatuses
+    singular: nodestatus
+    kind: NodeStatus
+    shortNames:
+      - nstat
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/crds/services.yaml
+++ b/crds/services.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: services.ha.example.com
+spec:
+  group: ha.example.com
+  scope: Namespaced
+  names:
+    plural: services
+    singular: service
+    kind: Service
+    shortNames:
+      - svc
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/crds/servicespecs.yaml
+++ b/crds/servicespecs.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicespecs.ha.example.com
+spec:
+  group: ha.example.com
+  scope: Namespaced
+  names:
+    plural: servicespecs
+    singular: servicespec
+    kind: ServiceSpec
+    shortNames:
+      - svcspec
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/crds/subscriptions.yaml
+++ b/crds/subscriptions.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.ha.example.com
+spec:
+  group: ha.example.com
+  scope: Namespaced
+  names:
+    plural: subscriptions
+    singular: subscription
+    kind: Subscription
+    shortNames:
+      - sub
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Summary
- add CustomResourceDefinition templates for services, service specs, subscriptions, and node statuses under crds/

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Tunnel connection failed: 403)*


------
https://chatgpt.com/codex/tasks/task_e_68919a26d690833193f3aad2f5c98fdc