### PR TITLE
Send tensor directly to gesture worker

### DIFF
--- a/processor/single_processor.py
+++ b/processor/single_processor.py
@@ -22,6 +22,6 @@ class SingleFrameProcessor:
         if not acquired:
             raise TimeoutError("timed out waiting for the worker lock")
         try:
-            return self.worker.predict([frame])[0]
+            return self.worker.predict(frame)
         finally:
             self._lock.release()


### PR DESCRIPTION
## Summary
- Pass frames directly to the worker in `SingleFrameProcessor.predict`
- Return the full `(boxes, labels, probs)` tuple from the worker

## Testing
- `pytest`
- Manual gRPC call to gesture service


------
https://chatgpt.com/codex/tasks/task_e_6891a340225883319752c73053904838