### PR TITLE
feat: add request dropper to gesture and pose services

### DIFF
--- a/core/droppable_processor.py
+++ b/core/droppable_processor.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from core.request_dropper import RequestDropper, RequestTimeoutError
+from processor.single_processor import SingleFrameProcessor
+
+
+class DroppableSingleProcessor:
+    """Wraps a :class:`SingleFrameProcessor` with request dropping logic.
+
+    This wrapper ensures that requests exceeding the configured wait time
+    are discarded before GPU resources are used. Services should interact
+    with this class instead of ``RequestDropper`` directly so the dropping
+    behaviour remains encapsulated within business logic.
+    """
+
+    def __init__(self, worker, dropper: RequestDropper | None = None):
+        self._processor = SingleFrameProcessor(worker)
+        self._dropper = dropper or RequestDropper()
+
+    def mark(self) -> float:
+        """Mark the enqueue time for an incoming request."""
+        return self._dropper.mark()
+
+    def predict(self, frame, enqueue_time: float):
+        """Run prediction if the request has not timed out."""
+        return self._dropper.run(self._processor.predict, enqueue_time, frame)
+

--- a/service/gesture_service.py
+++ b/service/gesture_service.py
@@ -2,12 +2,13 @@ from datetime import datetime
 from proto import gesture_pb2_grpc
 from proto import gesture_pb2
 from model.gesture_worker import GestureWorker
-from processor.single_processor import SingleFrameProcessor
 from utils.logger import logger_context, get_logger
 from processor.preprocessor import GesturePreprocessor
 from processor.postprocessor import GesturePostprocessor
 from metrics.registry import monitorRegistry
 from infra.request_queue import RequestQueue
+from core.droppable_processor import DroppableSingleProcessor
+from core.request_dropper import RequestTimeoutError
 
 
 class GestureDetectionService(gesture_pb2_grpc.GestureRecognitionServicer):
@@ -17,7 +18,7 @@ class GestureDetectionService(gesture_pb2_grpc.GestureRecognitionServicer):
         self.worker = GestureWorker()
         self.preprocessor = GesturePreprocessor()
         self.postprocessor = GesturePostprocessor()
-        self.processor = SingleFrameProcessor(self.worker)
+        self.processor = DroppableSingleProcessor(self.worker)
         self.logger = get_logger(__name__)
         self.queue = request_queue
         self.frame_index = 0
@@ -28,6 +29,7 @@ class GestureDetectionService(gesture_pb2_grpc.GestureRecognitionServicer):
             rps.increment()
 
         self.queue.enqueue(1)
+        enqueue_time = self.processor.mark()
         client_ip = context.peer().split(":")[-1].replace("ipv4/", "")
         with logger_context() as logger:
             logger.set_mark("start")
@@ -42,11 +44,15 @@ class GestureDetectionService(gesture_pb2_grpc.GestureRecognitionServicer):
             with logger.phase("preprocess"):
                 frame = self.preprocessor.process(request.image)
 
-            with logger.phase("inference"):
-                result = self.processor.predict(frame)
-
-            with logger.phase("postprocess"):
-                action = self.postprocessor.process(result)
+            try:
+                with logger.phase("inference"):
+                    result = self.processor.predict(frame, enqueue_time)
+            except RequestTimeoutError:
+                action = ""
+                logger.update({"dropped": True})
+            else:
+                with logger.phase("postprocess"):
+                    action = self.postprocessor.process(result)
 
             logger.write()
 

--- a/service/pose_service_no_batch.py
+++ b/service/pose_service_no_batch.py
@@ -2,13 +2,13 @@ from datetime import datetime
 from proto import pose_pb2_grpc
 from proto import pose_pb2
 from model.batch_worker import BatchWorker
-from processor.single_processor import SingleFrameProcessor
 from utils.logger import logger_context, get_logger
 from processor.preprocessor import PosePreprocessor
 from processor.postprocessor import PosePostprocessor
 from metrics.registry import monitorRegistry
 from infra.request_queue import RequestQueue
-from core.request_dropper import RequestDropper, RequestTimeoutError
+from core.droppable_processor import DroppableSingleProcessor
+from core.request_dropper import RequestTimeoutError
 
 
 class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
@@ -18,8 +18,7 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
         self.worker = BatchWorker()
         self.preprocessor = PosePreprocessor()
         self.postprocessor = PosePostprocessor()
-        self.processor = SingleFrameProcessor(self.worker)
-        self.dropper = RequestDropper()
+        self.processor = DroppableSingleProcessor(self.worker)
         self.logger = get_logger(__name__)
         self.queue = request_queue
 
@@ -30,7 +29,7 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
 
         # enqueue request for queue size monitoring
         self.queue.enqueue(1)
-        enqueue_time = self.dropper.mark()
+        enqueue_time = self.processor.mark()
 
         client_ip = context.peer().split(":")[-1].replace("ipv4/", "")
         with logger_context() as logger:
@@ -48,7 +47,7 @@ class PoseDetectionServiceNoBatch(pose_pb2_grpc.MirrorServicer):
 
             try:
                 with logger.phase("inference"):
-                    result = self.dropper.run(self.processor.predict, enqueue_time, frame)
+                    result = self.processor.predict(frame, enqueue_time)
             except RequestTimeoutError:
                 processed = ""
                 logger.update({"dropped": True})


### PR DESCRIPTION
## Summary
- encapsulate request dropping in `DroppableSingleProcessor`
- drop overdue requests in gesture service before inference
- reuse drop logic in `PoseDetectionServiceNoBatch`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a561aaa608331a408932bbfe953e7